### PR TITLE
Add 'extensions' hook for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 dist
 build
+__pycache__

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ Plugins can provide:
 * *globals*: functions used in Jinja2 templates to obtain data from
   external sources.
 
+* *extensions*: Jinja2 extensions that can add extra filters, tests,
+  globals or even extend the parser.
+
 For more details on the functionality and requirements for 'filters',
-'tests', and 'globals', refer to the Jinja2 documentation.
+'tests', 'globals', and 'extensions', refer to the Jinja2 documentation.
 
 ## Installation
 
@@ -131,6 +134,7 @@ from jinjanator_plugins import (
     plugin_formats_hook,
     plugin_identity_hook,
     plugin_tests_hook,
+    plugin_extensions_hook,
 )
 
 
@@ -188,6 +192,11 @@ def plugin_tests():
 @plugin_formats_hook
 def plugin_formats():
     return {SpamFormat.name: SpamFormat}
+
+
+@plugin_extensions_hook
+def plugin_extensions():
+    return ['jinja2.ext.debug']
 ```
 
 Note that the real example makes use of type annotations, but they
@@ -322,6 +331,28 @@ requirements.
 
 * `FormatOptionValueError` should be raised when a provided option has
   a value that is not valid.
+
+#### plugin_extensions
+
+The hook function which will be called by Jinjanator to allow this
+plugin to register any additional Jinja2 extensions; the
+`@plugin_extensions_hook` decorator marks the function so that it will be
+found.
+
+The function must return a list, with each entry being a string (the name
+of a Jinja2 extension that should be added to the Jinja2 Environment).
+
+Those strings should correspond to extensions that themselves are available
+in your python installation and available for Jinja2 to locate.
+
+Some examples:
+* Jinja2 own debug extension: `jinja2.ext.debug`
+* [Jinja-Markdown](https://github.com/jpsca/jinja-markdown): `jinja_markdown.MarkdownExtension`
+* [jinja-markdown2](https://github.com/mkbabb/jinja-markdown2): `jinja2_markdown.MarkdownExtension`
+* https://github.com/topics/jinja2-extension etc...
+
+Note that the function *must* be named `plugin_extensions`; it is the
+second part of the 'magic' mechanism mentioned above.
 <!-- fancy-readme end -->
 
 ## Chat

--- a/plugin_example/jinjanator_plugin_example.py
+++ b/plugin_example/jinjanator_plugin_example.py
@@ -5,6 +5,7 @@ import codecs
 from typing import Iterable, Mapping
 
 from jinjanator_plugins import (
+    Extensions,
     Filters,
     FormatOptionUnknownError,
     FormatOptionUnsupportedError,
@@ -12,6 +13,7 @@ from jinjanator_plugins import (
     Formats,
     Identity,
     Tests,
+    plugin_extensions_hook,
     plugin_filters_hook,
     plugin_formats_hook,
     plugin_identity_hook,
@@ -82,3 +84,8 @@ def plugin_tests() -> Tests:
 @plugin_formats_hook
 def plugin_formats() -> Formats:
     return {SpamFormat.name: SpamFormat}
+
+
+@plugin_extensions_hook
+def plugin_extensions() -> Extensions:
+    return ["jinja2.ext.debug"]

--- a/src/jinjanator_plugins/__init__.py
+++ b/src/jinjanator_plugins/__init__.py
@@ -79,12 +79,14 @@ Formats: TypeAlias = Mapping[str, Type[Format]]
 Filters: TypeAlias = Mapping[str, Callable[..., Any]]
 Globals: TypeAlias = Mapping[str, Callable[..., Any]]
 Tests: TypeAlias = Mapping[str, Callable[..., Any]]
+Extensions: TypeAlias = Iterable[str]
 
 PluginIdentityHook: TypeAlias = Callable[[], Identity]
 PluginFormatsHook: TypeAlias = Callable[[], Formats]
 PluginFiltersHook: TypeAlias = Callable[[], Filters]
 PluginTestsHook: TypeAlias = Callable[[], Tests]
 PluginGlobalsHook: TypeAlias = Callable[[], Globals]
+PluginExtensionsHook: TypeAlias = Callable[[], Extensions]
 
 plugin_identity_hook = cast(
     Callable[[PluginIdentityHook], PluginIdentityHook],
@@ -104,6 +106,10 @@ plugin_tests_hook = cast(
 )
 plugin_globals_hook = cast(
     Callable[[PluginGlobalsHook], PluginGlobalsHook],
+    pluggy.HookimplMarker("jinjanator"),
+)
+plugin_extensions_hook = cast(
+    Callable[[PluginExtensionsHook], PluginExtensionsHook],
     pluggy.HookimplMarker("jinjanator"),
 )
 
@@ -134,6 +140,11 @@ class PluginHooks(Protocol):
     def plugin_tests() -> Tests:
         """Returns dict of test functions"""
 
+    @staticmethod
+    @hookspec
+    def plugin_extensions() -> Extensions:
+        """Returns list of extensions to add to Jinja2"""
+
 
 class PluginHookCallers(Protocol):
     @staticmethod
@@ -155,3 +166,7 @@ class PluginHookCallers(Protocol):
     @staticmethod
     def plugin_tests() -> Iterable[Tests]:
         """Returns iterable of dicts of test functions"""
+
+    @staticmethod
+    def plugin_extensions() -> Iterable[Extensions]:
+        """Returns iterable of list of extensions to add to Jinja2"""


### PR DESCRIPTION
This new hook allows to add new [Jinja2 extensions](https://jinja.palletsprojects.com/en/3.1.x/extensions/) in the Environment.